### PR TITLE
single expander for both graph sets

### DIFF
--- a/components/charts/category-bar.js
+++ b/components/charts/category-bar.js
@@ -61,6 +61,7 @@ const CategoryBar = ({ label, total, mapping, expanded, showExpander }) => {
       <Box sx={{ mt: [4, '38px', '38px', '38px'], position: 'relative' }}>
         {showExpander && (
           <Expander
+            id='expander'
             value={expanded}
             sx={{
               position: 'absolute',

--- a/components/charts/project-charts.js
+++ b/components/charts/project-charts.js
@@ -58,12 +58,9 @@ const ProjectCharts = () => {
         letterSpacing: 'mono',
         textTransform: 'uppercase',
         cursor: 'pointer',
-        '&:hover': {
-          transform: 'translateY(-1px)',
-          transition: 'transform 0.3s ease',
+        '&:hover #expander': {
+          stroke: 'primary',
         },
-        transform: 'none',
-        transition: 'transform 0.3s ease',
       }}
     >
       <Column start={1} width={[6, 4, 4, 4]}>


### PR DESCRIPTION
closes #23  

went with a maybe overly expansive click surface for this - curious what you think. Could easily wire it up to open and close only on clicking the graphs instead of the whole row. also added a little animation on hover to indicate that it is alive!