### PR TITLE
Table row alignment improvements

### DIFF
--- a/components/project-row.js
+++ b/components/project-row.js
@@ -152,7 +152,8 @@ const ProjectRow = ({ project }) => {
                 >
                   <RotatingArrow
                     sx={{
-                      mb: '1px',
+                      mt: [1, 1, 1, 0],
+                      mb: [0, 0, 0, '1px'],
                       width: 14,
                       height: 14,
                       color: expanded ? color : null,


### PR DESCRIPTION
Couple little tweaks here. The arrow bump isn't ideal - there's likely a better way to get that thing centered but I wasn't having luck. 