### PR TITLE
`ListFilter` improvements

### DIFF
--- a/components/list-filter.js
+++ b/components/list-filter.js
@@ -3,8 +3,13 @@ import { X } from '@carbonplan/icons'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Box, Flex, IconButton } from 'theme-ui'
 
-const ListFilter = ({ items, selectedItems, title, placeholder, setter }) => {
-  const [selection, setSelection] = useState(false)
+export const ListSelection = ({
+  items,
+  selectedItems,
+  setSelection,
+  placeholder,
+  setter,
+}) => {
   const [query, setQuery] = useState('')
   const ref = useRef()
 
@@ -45,10 +50,8 @@ const ListFilter = ({ items, selectedItems, title, placeholder, setter }) => {
   )
 
   useEffect(() => {
-    if (selection) {
-      ref.current.focus()
-    }
-  }, [selection])
+    ref.current.focus()
+  }, [])
 
   // handle keyboard navigation of filtered countries
   const [focusedIndex, setFocusedIndex] = useState(-1)
@@ -72,10 +75,122 @@ const ListFilter = ({ items, selectedItems, title, placeholder, setter }) => {
 
   useEffect(() => {
     setFocusedIndex(-1)
-  }, [query, selection])
+  }, [query])
 
   return (
     <Box onKeyDown={handleKeyDown}>
+      <Box sx={{ position: 'relative' }}>
+        <Input
+          ref={ref}
+          sx={{
+            fontFamily: 'mono',
+            fontSize: 1,
+            mt: 3,
+            mb: 2,
+            width: '100%',
+          }}
+          placeholder={placeholder}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <IconButton
+          onClick={() => {
+            setSelection(false)
+            setter([])
+            setQuery('')
+          }}
+          sx={{
+            position: 'absolute',
+            right: 0,
+            bottom: -1,
+            width: 22,
+            color: 'secondary',
+            cursor: 'pointer',
+            '&:hover': { color: 'primary' },
+          }}
+        >
+          <X />
+        </IconButton>
+      </Box>
+      {selectedItems.length > 0 && (
+        <Flex sx={{ flexWrap: 'wrap', gap: 1, mt: 3 }}>
+          {selectedItems.map((item) => (
+            <Badge
+              sx={{
+                color: 'primary',
+                height: 'fit-content',
+              }}
+              key={item}
+            >
+              <Button
+                sx={{
+                  fontFamily: 'mono',
+                  fontSize: 1,
+                  py: '3px',
+                }}
+                suffix={<X sx={{ height: 10, width: 10 }} />}
+                onClick={() => removeItem(item)}
+              >
+                {item}
+              </Button>
+            </Badge>
+          ))}
+        </Flex>
+      )}
+      <Flex
+        sx={{
+          flexDirection: 'column',
+          gap: 2,
+          mt: selectedItems.length > 0 ? 2 : 3,
+          maxHeight: '300px',
+          overflowY: 'auto',
+          pr: [4, 5, 5, 6],
+          mr: [-4, -5, -5, -6],
+        }}
+      >
+        {filtered.map((item, i) => (
+          <Button
+            inverted
+            key={item}
+            size='xs'
+            sx={{
+              fontFamily: 'mono',
+              fontSize: 1,
+              '&:focus': {
+                color: 'primary',
+                backgroundColor: 'transparent !important',
+                outline: 'none !important',
+              },
+            }}
+            onClick={() => addItem(item)}
+            ref={(el) => (filteredItemsRefs.current[i] = el)}
+            onKeyDown={(e) => e.key === 'Enter' && addItem(item)}
+          >
+            {item}
+          </Button>
+        ))}
+        {hidden > 0 && (
+          <Box
+            sx={{
+              fontFamily: 'mono',
+              fontSize: 1,
+              color: 'secondary',
+              mt: 2,
+            }}
+          >
+            +{hidden} more
+          </Box>
+        )}
+      </Flex>
+    </Box>
+  )
+}
+
+const ListFilter = ({ items, selectedItems, title, placeholder, setter }) => {
+  const [selection, setSelection] = useState(false)
+
+  return (
+    <Box>
       <Filter
         values={{
           All: !selection,
@@ -92,111 +207,13 @@ const ListFilter = ({ items, selectedItems, title, placeholder, setter }) => {
         }}
       />
       {selection && (
-        <>
-          <Box sx={{ position: 'relative' }}>
-            <Input
-              ref={ref}
-              sx={{
-                fontFamily: 'mono',
-                fontSize: 1,
-                mt: 3,
-                mb: 2,
-                width: '100%',
-              }}
-              placeholder={placeholder}
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-            />
-            <IconButton
-              onClick={() => {
-                setSelection(false)
-                setter([])
-                setQuery('')
-              }}
-              sx={{
-                position: 'absolute',
-                right: 0,
-                bottom: -1,
-                width: 22,
-                color: 'secondary',
-                cursor: 'pointer',
-                '&:hover': { color: 'primary' },
-              }}
-            >
-              <X />
-            </IconButton>
-          </Box>
-          {selectedItems.length > 0 && (
-            <Flex sx={{ flexWrap: 'wrap', gap: 1, mt: 3 }}>
-              {selectedItems.map((item) => (
-                <Badge
-                  sx={{
-                    color: 'primary',
-                    height: 'fit-content',
-                  }}
-                  key={item}
-                >
-                  <Button
-                    sx={{
-                      fontFamily: 'mono',
-                      fontSize: 1,
-                      py: '3px',
-                    }}
-                    suffix={<X sx={{ height: 10, width: 10 }} />}
-                    onClick={() => removeItem(item)}
-                  >
-                    {item}
-                  </Button>
-                </Badge>
-              ))}
-            </Flex>
-          )}
-          <Flex
-            sx={{
-              flexDirection: 'column',
-              gap: 2,
-              mt: selectedItems.length > 0 ? 2 : 3,
-              maxHeight: '300px',
-              overflowY: 'auto',
-              pr: [4, 5, 5, 6],
-              mr: [-4, -5, -5, -6],
-            }}
-          >
-            {filtered.map((item, i) => (
-              <Button
-                inverted
-                key={item}
-                size='xs'
-                sx={{
-                  fontFamily: 'mono',
-                  fontSize: 1,
-                  '&:focus': {
-                    color: 'primary',
-                    backgroundColor: 'transparent !important',
-                    outline: 'none !important',
-                  },
-                }}
-                onClick={() => addItem(item)}
-                ref={(el) => (filteredItemsRefs.current[i] = el)}
-                onKeyDown={(e) => e.key === 'Enter' && addItem(item)}
-              >
-                {item}
-              </Button>
-            ))}
-            {hidden > 0 && (
-              <Box
-                sx={{
-                  fontFamily: 'mono',
-                  fontSize: 1,
-                  color: 'secondary',
-                  mt: 2,
-                }}
-              >
-                +{hidden} more
-              </Box>
-            )}
-          </Flex>
-        </>
+        <ListSelection
+          items={items}
+          selectedItems={selectedItems}
+          setSelection={setSelection}
+          placeholder={placeholder}
+          setter={setter}
+        />
       )}
     </Box>
   )

--- a/components/list-filter.js
+++ b/components/list-filter.js
@@ -187,7 +187,7 @@ export const ListSelection = ({
 }
 
 const ListFilter = ({ items, selectedItems, title, placeholder, setter }) => {
-  const [selection, setSelection] = useState(false)
+  const [selection, setSelection] = useState(selectedItems.length > 0)
 
   return (
     <Box>


### PR DESCRIPTION
This PR fixes the `ListFilter` state initialization so that the element always reflects the queries state on initialization (e.g., when navigating `back` to the landing page from a project-specific view). This PR also includes the refactor from #60 that makes `ListSelection` a separate export to avoid merge conflicts.

cc @andersy005 